### PR TITLE
fix(install): accept comma-separated -a and validate agent names

### DIFF
--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -66,6 +66,24 @@ export function registerInstallCommand(program: Command) {
                 // Determine agents
                 let agents: string[] = options.agent || [];
 
+                // Normalize: accept both space-separated (`-a claude cursor`)
+                // and comma-separated (`-a claude,cursor`) forms.
+                agents = agents
+                    .flatMap((a: string) => a.split(','))
+                    .map((a: string) => a.trim())
+                    .filter((a: string) => a.length > 0);
+
+                // Validate agent names so an unknown agent surfaces a clear
+                // error instead of crashing later on `AGENTS[agent].projectDir`.
+                const unknownAgents = agents.filter((a: string) => !AGENTS[a]);
+                if (unknownAgents.length > 0) {
+                    const known = Object.keys(AGENTS).join(', ');
+                    console.error(chalk.red(`✖ Unknown agent(s): ${unknownAgents.join(', ')}`));
+                    console.error(chalk.gray(`  Valid agents: ${known}`));
+                    console.error(chalk.gray(`  Pass multiple agents space- or comma-separated (e.g. -a claude cursor  or  -a claude,cursor)`));
+                    process.exit(1);
+                }
+
                 // --all flag: install to all agents
                 if (options.all) {
                     agents = Object.keys(AGENTS);


### PR DESCRIPTION
## Problem

`agent-skills-cli@1.1.8` crashes when `-a` is given a comma-separated list:

$ npx agent-skills-cli install .git -a claude,cursor -y
Error installing skill: Cannot read properties of undefined (reading 'projectDir')

## Root cause

`install.ts:48` declares `-a, --agent <agents...>` (commander variadic = space-separated). When a
user passes `-a claude,cursor`, the single string `"claude,cursor"` ends up as `agents[0]`.
Downstream code does `AGENTS[agents[0]].projectDir` (e.g. `install.ts:228`) which throws because
`AGENTS["claude,cursor"]` is `undefined`.

## Fix

1. Normalize `options.agent` so both `-a claude cursor` and `-a claude,cursor` work. Matches
conventions in docker / kubectl / many other CLIs.
2. Validate each agent name against `AGENTS`. Unknown agents now exit with a clear error listing the
valid agent names instead of crashing on an undefined lookup.

## Reproduce / verify

```bash
# Before: crashes
agent-skills-cli install <repo>.git -a claude,cursor -y

# After: works the same as space-separated
agent-skills-cli install <repo>.git -a claude,cursor -y
agent-skills-cli install <repo>.git -a claude cursor -y

# Unknown agent: clean error
agent-skills-cli install <repo>.git -a nope -y
# -> ✖ Unknown agent(s): nope
```

Closes #13
